### PR TITLE
Ensure a default time value is set

### DIFF
--- a/routes/book-1/js/book-1.js
+++ b/routes/book-1/js/book-1.js
@@ -62,13 +62,14 @@ const setSchedulerOptions = (eventData) => {
         firstDay = new Date(firstDay.getTime() + oneDay)
       }
       const lastAvailableDate = dayjs(today).add(daterange_days, "days");
+      const time_values = populateTimes(start_hour, end_hour, duration_minutes);
       return {
         today: dayjs(today),
         firstAvailableDate: dayjs(firstDay),
         lastAvailableDate: lastAvailableDate,
         date: dayjs(firstDay).format("YYYY-MM-DD"),
-        time: "",
-        time_values: populateTimes(start_hour, end_hour, duration_minutes),
+        time: time_values[0].val,
+        time_values: time_values,
         isBlockedDay: isBlockedDay,
         selected: [dayjs(firstDay).format("YYYY-MM-DD")],
         focusedDayNum: dayjs(firstDay).format("D"),


### PR DESCRIPTION
Fix for #1 

I initially thought this was an upstream-change, but just setting it in the downstream default state appears to fix it. There's a similar PR here with more information: https://github.com/cds-snc/notification-scheduler/pull/15 , but the notification-scheduler PR is not a requirement for this PR to work.